### PR TITLE
Fix issues in the sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,27 @@
 # spring-cloud-az-kv
 
-Read [https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_4.0.0-beta.2/keyvault/spring-cloud-azure-starter-keyvault-secrets/single-property-source](https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_4.0.0-beta.2/keyvault/spring-cloud-azure-starter-keyvault-secrets/single-property-source)
+Read [Spring Cloud Azure KV Secret Sample](https://github.com/Azure-Samples/azure-spring-boot-samples/tree/spring-cloud-azure_v4.0.0/keyvault/spring-cloud-azure-starter-keyvault-secrets/property-source)
 
+0. prepare the KV
+
+you need to create a KV in Azure and set the following secrets:
+
+* FOO
+* MYSQL-SERVER-FULL-NAME
+
+
+1. az login with Azure CLI
+
+So you don't need to have any credential in your application properties
+
+```
+az login
+```
+
+then build and run your spring boot application
+
+```shell
 mvn clean package -DskipTests
+java -jar target/spring-cloud-azure-starter-keyvault-secrets-sample-single-property-source-1.0.0.jar --spring.profiles.active=azure "--spring.cloud.azure.keyvault.secret.property-sources[0].endpoint=YOUR_KEY_VAULT_ENDPOINT"
+```
 
-java -jar .\target\spring-cloud-azure-starter-keyvault-secrets-sample-single-property-source-1.0.0.jar --spring.profiles.active=az
-
-java -jar .\target\spring-cloud-azure-starter-keyvault-secrets-sample-single-property-source-1.0.0.jar --spring.profiles.active=az --spring.cloud.azure.profile.keyvault.secret.endpoint=https://kv-XXX.vault.azure.net --spring.cloud.azure.profile.tenant-id=XXX --spring.cloud.azure.profile.credential.client-id=XXXX --spring.cloud.azure.profile.credential.client-secret=XXXX"

--- a/pom.xml
+++ b/pom.xml
@@ -27,21 +27,7 @@
 
 	<dependencies>
 
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-dependencies</artifactId>
-			<version>${spring-cloud.version}</version>
-			<type>pom</type>
-			<scope>import</scope>
-		</dependency>
 
-		<dependency>
-			<groupId>com.azure.spring</groupId>
-			<artifactId>spring-cloud-azure-dependencies</artifactId>
-			<version>${spring-cloud-azure.version}</version>
-			<type>pom</type>
-			<scope>import</scope>
-		</dependency>
 
 		<dependency>
 			<groupId>com.azure.spring</groupId>
@@ -64,10 +50,6 @@
 		</dependency>
 		-->
 
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-bootstrap</artifactId>
-		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/resources/application-azure.yml
+++ b/src/main/resources/application-azure.yml
@@ -4,9 +4,4 @@ spring:
       keyvault:
         secret:
           property-sources:
-            - credential:
-                client-id: ${AZURE_CLIENT_ID}
-                client-secret: ${AZURE_CLIENT_SECRET}
-              endpoint: ${ENDPOINT}
-              profile:
-                tenant-id: ${AZURE_TENANT_ID}
+              - endpoint: ${AZURE_KV_ENDPOINT}


### PR DESCRIPTION
1. BOM should be used in the <dependencyManagement> section of pom.xml only with 'import' scope
2. spring-cloud-starter-bootstrap dependency is not required since spring boot 2.4, and this sample uses spring boot 2.6
3. simplify application properties, to leverage our enhancement made in 4.0, so you don't need to have client id and client secret, but this is optional
4. fix readme, the original command is using '--spring.profiles.active=az' but properties file is named 'application-azure.yml', so we need to change it to '--spring.profiles.active=azure'